### PR TITLE
PDF build for documentation

### DIFF
--- a/adi_doctools/__init__.py
+++ b/adi_doctools/__init__.py
@@ -58,12 +58,22 @@ def config_inited(app, config):
     # Inject version value, config entry has higher precedence
     if 'version' not in config:
         doc_version = getenv("ADOC_DOC_VERSION", default="")
+    doc_version = getenv("ADOC_DOC_VERSION", default="")
+
+    # parameter used for PDF output mode
+    media_print = getenv("ADOC_MEDIA_PRINT", default=0)
+    media_print = True if media_print == '1' else False
+    config.media_print = media_print
+
+    if 'version' not in config or config.version == "":
         try:
             doc_version = str(Version(doc_version))
         except Exception as err:
             pass
         config.version = doc_version
-
+    elif doc_version != "":
+        logger.warning("ADOC_DOC_VERSION set but ignored due to "
+                    "conf.py version entry")
 
 def builder_inited(app):
     if app.builder.format == 'html':

--- a/adi_doctools/__init__.py
+++ b/adi_doctools/__init__.py
@@ -58,22 +58,15 @@ def config_inited(app, config):
     # Inject version value, config entry has higher precedence
     if 'version' not in config:
         doc_version = getenv("ADOC_DOC_VERSION", default="")
-    doc_version = getenv("ADOC_DOC_VERSION", default="")
-
-    # parameter used for PDF output mode
-    media_print = getenv("ADOC_MEDIA_PRINT", default=0)
-    media_print = True if media_print == '1' else False
-    config.media_print = media_print
-
-    if 'version' not in config or config.version == "":
         try:
             doc_version = str(Version(doc_version))
         except Exception as err:
             pass
         config.version = doc_version
-    elif doc_version != "":
-        logger.warning("ADOC_DOC_VERSION set but ignored due to "
-                    "conf.py version entry")
+    # Parameter to enable PDF output tweaks
+    media_print = getenv("ADOC_MEDIA_PRINT", default="0")
+    media_print = True if media_print == "1" else False
+    config.media_print = media_print
 
 def builder_inited(app):
     if app.builder.format == 'html':

--- a/adi_doctools/directive/common.py
+++ b/adi_doctools/directive/common.py
@@ -101,7 +101,7 @@ class directive_base(Directive):
                                   uid=uid)
         rows.append(row)
 
-    def generic_table(self, description, uid: Optional[str]=None):
+    def generic_table(self, description, uid: Optional[str]=None, media_print=False):
         tgroup = nodes.tgroup(cols=2)
         for _ in range(2):
             colspec = nodes.colspec(colwidth=1)
@@ -109,17 +109,24 @@ class directive_base(Directive):
         table = nodes.table()
         table += tgroup
 
+        # example: self.table_header(tgroup, ["Bear with me", "Description"])
         self.table_header(tgroup, ["Name", "Description"])
 
         rows = []
         for key in description:
             row = nodes.row()
+            
             entry = nodes.entry()
-            entry += nodes.literal(text="{:s}".format(key))
+            if not media_print:  # Check if not in PDF mode
+                entry += nodes.literal(text="{:s}".format(key))
+            else:
+                entry += nodes.paragraph(text="{:s}".format(key))  # Use paragraph for PDF mode
             row += entry
+            
             entry = nodes.entry()
             entry += parse_rst(self.state, description[key], uid=uid)
             row += entry
+            
             rows.append(row)
 
         tbody = nodes.tbody()
@@ -154,8 +161,7 @@ class directive_base(Directive):
 
         thead.append(row)
 
-    def collapsible(self, section,
-                    text: [str, Tuple[str, str]] = "", node=None):
+    def collapsible(self, section, text: [str, Tuple[str, str]] = "", node=None):
         """
         Creates a collapsible content.
         text: When a tuple, the first string is a unique id, useful when the

--- a/adi_doctools/directive/hdl.py
+++ b/adi_doctools/directive/hdl.py
@@ -4,7 +4,6 @@ from docutils.parsers.rst import directives
 import re
 from os import path, walk
 from os import pardir, makedirs
-from typing import Final
 from math import ceil
 from lxml import etree
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,11 +6,16 @@ repository = 'doctools'
 project = 'Doctools'
 copyright = '2024, Analog Devices, Inc.'
 author = 'Analog Devices, Inc.'
+version = '0.3'
+
+locale_dirs = ['locales/']  # path is relative to the source directory
+language = 'en'
 
 # -- General configuration ---------------------------------------------------
 
 extensions = [
-    "adi_doctools",
+    'adi_doctools',
+    'rst2pdf.pdfbuilder'
 ]
 
 needs_extensions = {
@@ -23,6 +28,9 @@ source_suffix = '.rst'
 # -- Custom extensions configuration ------------------------------------------
 
 export_metadata = True
+
+#  -- Options for PDF output --------------------------------------------------
+# draft comment, future options for exporting to PDF
 
 # -- Options for HTML output --------------------------------------------------
 

--- a/docs/docs_guidelines.rst
+++ b/docs/docs_guidelines.rst
@@ -134,6 +134,29 @@ if the target directory is:
 * *./prs/1234*: ``2``
 * *./staging/user/branch*: ``3``
 
+Exporting to PDF
+--------------------------------------------------------------------------------
+
+The whole documentation can be exported to a PDF document for a more compact 
+format. This is done by setting the enviroment variable called 
+``ADOC_MEDIA_PRINT`` to 1 (default it's 0) and building the documentation using 
+this command:
+
+.. code-block::
+
+   user@analog:~/doctools/docs$ sphinx-build -b pdf .  _build/pdfbuild
+
+In the output folder, you’ll find a PDF document named after the repository 
+(e.g. Doctools.pdf). This document includes an auto-generated cover, followed by
+the remaining pages. Note that an HTML build of the documentation is not
+required for the PDF build.
+
+.. warning::
+
+   The enviroment variable ``ADOC_MEDIA_PRINT`` should be set to 0 when building
+   the HTML pages of documentation. If not set, some components of the pages
+   may not render properly. 
+
 References
 --------------------------------------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 sphinx
+matplotlib
+rst2pdf
+svglib
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz


### PR DESCRIPTION
Using RTF2PDF, there is now the option for outputting the whole HDL documentation in PDF format. The following changes were made:
* new variable used to signal PDF output mode, called **ADOC_MEDIA_PRINT** (export ADOC_MEDIA_PRINT=value)
	* 1 for PDF output mode, which changes the HTML output a little bit (only visually, for example some things are not highlighted anymore); used this only when exporting to PDF
	* 0 default, no need to be set
*  to build the PDF, use this command `sphinx-build -b pdf .  _build/pdfbuild` in docs folder after setting the **ADOC_MEDIA_PRINT** variable; these libraries are needed to be installed
	* rst2pdf
	* matplotlib
	* svglib
* `conf.py` file from each repo needs to be changed to include `rst2pdf.pdfbuilder` extension
* the code that handles tables, collapsible etc. was changed so that the exported text is rendered correctly in PDF 

There are a few more issues that need to be tackled, but these problems are more styling related:
* some pictures are not properly sized, meaning that in some cases they are too small or too big
* in some cases, code examples (blocks which contain highlighted code) exit the page, they are not wrapped to continue on the next line
* a few .svg diagrams are not properly rendered (missing port names or connections between blocks)

This is a prototype, a bit more styling is needed, but functionally, all the info that is contained in HDL documentation can be found in the new outputted PDF document (no missing tables, like in the case of collapsible content which contained other pieces of information). 
The new PDF output method was tested on a select batch of pages from HDL (taken from docs/projects & docs/library) & on the whole HDL documentation. 