### PR TITLE
lut: add ad-r1m-ros2 repo

### DIFF
--- a/adi_doctools/lut.py
+++ b/adi_doctools/lut.py
@@ -178,6 +178,14 @@ repos = {
         branch='humble',
         visibility='public'
     ),
+    'ad-r1m-ros2': Repo(
+        pathname='ad_r1m/doc',
+        name='AD-R1M ROS2',
+        description='Open Mobile Robot Platform using ROS 2.',
+        category='sdk',
+        branch='main',
+        visibility='public'
+    ),
     'scopy': Repo(
         pathname='docs',
         name='Scopy',


### PR DESCRIPTION
Add AD-R1M ROS2 Open Mobile Robot Platform repository to the repos lookup table for use in landing pages.