### PR TITLE
lut: clarify ADSP Yocto docs

### DIFF
--- a/adi_doctools/lut.py
+++ b/adi_doctools/lut.py
@@ -94,8 +94,8 @@ repos = {
     ),
     'lnxdsp-adi-meta': Repo(
         pathname='docs',
-        name='ADI DSP Linux',
-        description='Yocto-based Linux images for ADI Digital Signal Processors.',
+        name='ADSP Yocto',
+        description='Yocto support for ADI Digital Signal Processors (ADSP).',
         category='driver',
         branch='main',
         visibility='public'


### PR DESCRIPTION
The Yocto repository only contains Yocto support. That doesn't include Linux, U-Boot, and Buildroot, which each have their own repositories. Generic documentation of the processors should be added to the System Level documentation.